### PR TITLE
removed reference to invalid raygui.h

### DIFF
--- a/src/template/projects/VS2022/project_name/project_name.vcxproj
+++ b/src/template/projects/VS2022/project_name/project_name.vcxproj
@@ -349,10 +349,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <!--Additional Include Items-->
-    <ClInclude Include="..\..\..\src\external\raygui.h" />
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="..\..\..\src\project_name.c" />
     <!--Additional Compile Items-->
     <!--<ClCompile Include="..\..\..\src\extra_module.c" />-->


### PR DESCRIPTION
- Testing Release 1.1
- Every project template generator (`Basic`, `Screen Manager`, `Custom`) includes a reference to `raygui.h` which is missing / invalid when you try to open it in Visual Studio 2022

![Screenshot 2024-09-30 165758](https://github.com/user-attachments/assets/3f2891e0-77cb-4314-9b35-c560a9021c09)

![Screenshot 2024-09-30 165828](https://github.com/user-attachments/assets/5fbd0f21-a9c0-48e3-8c32-14837e6bd842)
