### PR TITLE
Add support for custom raylib source directory via environment variable

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -325,7 +325,7 @@ $(PROJECT_NAME): $(OBJS)
 # Compile source files
 # NOTE: This pattern will compile every module defined on $(OBJS)
 %.o: %.c
-	$(CC) -c $< -o $@ $(CFLAGS) $(INCLUDE_PATHS) -D$(PLATFORM)
+	$(CC) -c $< -o $@ $(CFLAGS) $(INCLUDE_PATHS) -D$(PLATFORM) -DRAYLIB_SRC_PATH='"$(RAYLIB_SRC_PATH)"'
 
 # Clean everything
 clean:

--- a/src/raylib_project_creator.c
+++ b/src/raylib_project_creator.c
@@ -307,7 +307,7 @@ int main(int argc, char *argv[])
     //strcpy(config->project.srcFilePaths[0], argv[1]);
     //config->project.srcFileCount = 1;
     strcpy(config->building.compilerPath, "C:\\raylib\\w64devkit\\bin");
-    strcpy(config->building.raylibSrcPath, "C:\\raylib\\raylib\\src");
+    strcpy(config->building.raylibSrcPath, RAYLIB_SRC_PATH);
     strcpy(config->building.outputPath, ".");
 
     // Source file names (without path) are used for display on source textbox


### PR DESCRIPTION
Instead of having the raylib source path hardcoded, this change adds support for passing an environment variable during the build process. This provides flexibility for custom raylib installations and users of other systems, such as Linux.

An example of this would be:

```bash
RAYLIB_SRC_PATH=$HOME/dev/raylib/raylib-5.5/src/ make && ./raylib_project_creator
```
Result:

![2024-11-20_13-33](https://github.com/user-attachments/assets/8c088227-a328-4105-ad59-742429d8bf8b)
