### PR TITLE
VSCode CPP Properties doesn't have correct JSON formatting, shows error in VSCode

### DIFF
--- a/projects/VSCode/.vscode/c_cpp_properties.json
+++ b/projects/VSCode/.vscode/c_cpp_properties.json
@@ -4,7 +4,7 @@
             "name": "Win32",
             "includePath": [
                 "${workspaceFolder}/**",
-                "C:\GitHub\raylib\src/**",
+                "C:\\GitHub\\raylib\\src/**",
                 "../../src"
             ],
             "defines": [
@@ -14,7 +14,7 @@
                 "GRAPHICS_API_OPENGL_33",
                 "PLATFORM_DESKTOP"
             ],
-            "compilerPath": "C:\raylib\w64devkit\bin/gcc.exe",
+            "compilerPath": "C:\\raylib\\w64devkit\\bin/gcc.exe",
             "cStandard": "c99",
             "cppStandard": "c++14",
             "intelliSenseMode": "gcc-x64"
@@ -23,7 +23,7 @@
             "name": "Mac",
             "includePath": [
                 "${workspaceFolder}/**",
-                "C:\GitHub\raylib\src/**",
+                "C:\\GitHub\\raylib\\src/**",
                 "../../src/"
             ],
             "defines": [
@@ -45,7 +45,7 @@
             "name": "Linux",
             "includePath": [
                 "${workspaceFolder}/**",
-                "C:\GitHub\raylib\src/**",
+                "C:\\GitHub\\raylib\\src/**",
                 "../../src/"
             ],
             "defines": [


### PR DESCRIPTION
The c_cpp_properties.json file in the raylib project creator VSCode Template throws this error
![{1CC0DA53-92A4-47D0-B927-34233FE2B5C9}](https://github.com/user-attachments/assets/cdd832b8-4ae2-4281-9237-bc21d23b3167)
caused by lack of double backslash (\\\\), this PR fixes that issue